### PR TITLE
Link to stable version package on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ brew tap homebrew/cask-fonts
 brew cask install font-sudo
 ```
 
-### AUR
+### Arch Linux
 
-Sudo is available as an [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) package under the name 'sudo-font-git'.
+Sudo is available in the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository) as [ttf-sudo](https://aur.archlinux.org/packages/ttf-sudo).


### PR DESCRIPTION
The sudo-font-git package is still available, but building from git shouldn't be the default, better to link to the stable package first and let people that want to mess with VCS packages on their own.