### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Sudo is also available as a [Homebrew](https://brew.sh/) package.
 
 ```sh
 brew tap homebrew/cask-fonts
-brew cask install font-sudo
+brew install --cask font-sudo
 ```
 
 ### Arch Linux


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524