### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
       uses: actions/checkout@v4
     - name: Generate Changelog
       run: sed -n '/${{github.ref_name}}/,/^$/p' sudo/FONTLOG.txt | sed '1d; $d' > Release_Notes.txt
+    - name: Install WOFF Support
+      run: sudo apt install -y woff2 woff-tools
     - name: Install Debian Packaging Support
       run: sudo apt update && sudo apt -y install devscripts debhelper-compat
     - name: Build Debian Package
       run: scripts/prepare-deb.sh
-    - name: Install WOFF Support
-      run: sudo apt install -y woff2 woff-tools
     - name: Build
       run: make dist
     - name: Release


### PR DESCRIPTION
This PR addresses an issue in the release workflow by ensuring that the required WOFF dependencies are installed prior to the creation of the Debian package.

See [failing build](https://github.com/jenskutilek/sudo-font/actions/runs/8216052911/job/22470187426#step:5:49).
