### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Download the [latest release](https://github.com/jenskutilek/sudo-font/releases/
 Sudo is also available as a [Homebrew](https://brew.sh/) package.
 
 ```sh
-brew tap homebrew/cask-fonts
 brew install --cask font-sudo
 ```
 


### PR DESCRIPTION
Sudo has been migrated to `homebrew-cask` following the deprecation of the `homebrew-cask-fonts` repository.
